### PR TITLE
Disable the cache for the maven-source-plugin

### DIFF
--- a/src/main/java/io/quarkus/develocity/project/QuarkusProjectDevelocityConfigurationListener.java
+++ b/src/main/java/io/quarkus/develocity/project/QuarkusProjectDevelocityConfigurationListener.java
@@ -81,7 +81,7 @@ public class QuarkusProjectDevelocityConfigurationListener implements GradleEnte
                 new SurefireConfiguredPlugin(),
                 new FailsafeConfiguredPlugin(),
                 new EnforcerConfiguredPlugin(),
-                new SourceConfiguredPlugin(),
+                //new SourceConfiguredPlugin(),
                 new QuarkusConfiguredPlugin(),
                 new FormatterConfiguredPlugin(),
                 new ImpsortConfiguredPlugin(),

--- a/src/main/java/io/quarkus/develocity/project/plugins/SourceConfiguredPlugin.java
+++ b/src/main/java/io/quarkus/develocity/project/plugins/SourceConfiguredPlugin.java
@@ -46,5 +46,7 @@ public class SourceConfiguredPlugin extends SimpleQuarkusConfiguredPlugin {
             outputs.file("source-jar", context.getProject().getBuild().getDirectory() + "/"
                     + context.getProject().getBuild().getFinalName() + "-sources.jar");
         });
+
+        // we should add the source jar as an attached artifact but for now, we can't
     }
 }


### PR DESCRIPTION
Unfortunately, for this plugin to be cached, we would need to be able to attach the cached output as an artifact when present and we can't.