### PR TITLE
Update Maven/Wrapper/Develocity Versions for better Compatibility

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <develocity-maven-extension.version>1.21.6</develocity-maven-extension.version>
-        <maven-core.version>3.9.8</maven-core.version>
+        <develocity-maven-extension.version>1.22.2</develocity-maven-extension.version>
+        <maven-core.version>3.9.9</maven-core.version>
         <plexus-component.version>2.2.0</plexus-component.version>
         <sisu-inject.version>0.3.5</sisu-inject.version>
 


### PR DESCRIPTION
These changes solves quarkusio/quarkus#42756.

What i have done to check ?

1) Made commit changes.
2) ./mvnw clean install (quarkus-project-develocity-extension, 1.1.6-SNAPSHOT to make it visible via local m2) 3) Made some changes to https://github.com/quarkusio/quarkus/blob/main/.mvn/extensions.xml, which is now looking as below:

```
 <extensions>
    <extension>
        <groupId>com.gradle</groupId>
        <artifactId>develocity-maven-extension</artifactId>
        <version>1.22.2</version>
    </extension>
    <extension>
        <groupId>com.gradle</groupId>
        <artifactId>common-custom-user-data-maven-extension</artifactId>
        <version>2.0.1</version>
    </extension>
    <extension>
        <groupId>com.gradle</groupId>
        <artifactId>quarkus-build-caching-extension</artifactId>
        <version>1.8</version>
    </extension>
    <extension>
        <groupId>io.quarkus.develocity</groupId>
        <artifactId>quarkus-project-develocity-extension</artifactId>
        <version>1.1.6-SNAPSHOT</version>
    </extension>
</extensions>
```
4) cd into quarkus project git repository root directory on my disk drive 5) ./mvnw -Dquickly

Result looks like that:

```
...

[INFO] Quarkus - Documentation ............................ SUCCESS [ 10.929 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35:00 min
[INFO] Finished at: 2024-10-09T17:33:10+03:00
[INFO] ------------------------------------------------------------------------
[INFO] 14725 goals, 14709 executed, 16 from cache
```

This is only way how i finally successfully built Quarkus on my Windows machine via Maven Wrapper or even locally installed Maven of version 3.9.9