### PR TITLE
Disable resource usage capture

### DIFF
--- a/src/main/java/io/quarkus/develocity/project/QuarkusProjectDevelocityConfigurationListener.java
+++ b/src/main/java/io/quarkus/develocity/project/QuarkusProjectDevelocityConfigurationListener.java
@@ -48,6 +48,7 @@ public class QuarkusProjectDevelocityConfigurationListener implements Develocity
                     + mavenSession.getRequest().getBaseDirectory());
 
             develocityApi.getBuildScan().getPublishing().onlyIf(context -> false);
+            develocityApi.getBuildScan().getCapture().setResourceUsage(false);
             develocityApi.getBuildCache().getLocal().setEnabled(false);
             develocityApi.getBuildCache().getRemote().setEnabled(false);
 


### PR DESCRIPTION
From a strace output, it might be the root cause of the random permission denied issues we were having.

But still a bit unsure.